### PR TITLE
throw a helpful error if message is undefined

### DIFF
--- a/sha1.js
+++ b/sha1.js
@@ -5,6 +5,7 @@
 
   // The core
   sha1 = function (message) {
+    if (!message) { throw new Error('Cannot take SHA1 of undefined'); }
     // Convert to byte array
     if (message.constructor == String)
       message = utf8.stringToBytes(message);

--- a/test.js
+++ b/test.js
@@ -2,6 +2,10 @@ var sha1 = require('./sha1.js');
 var assert = require('assert');
 
 describe('sha1', function () {
+  it ('should throw an error if "message" is undefined', function () {
+    assert.throws(function () { sha1(undefined); }, "Cannot take SHA1 of undefined");
+  });
+
   it ('should return the expected SHA-1 hash for "message"', function () {
     assert.equal('6f9b9af3cd6e8b8a73c2cdced37fe9f59226e27d', sha1('message'));
   });


### PR DESCRIPTION
Thank you for this package! I've made one change locally and figured I would share.
Since `message.constructor` assumes that `message` exists, we get an unhelpful error `TypeError: Cannot read property 'constructor' of undefined` if `message` is undefined.